### PR TITLE
Provide post mortem link at web.archive.org

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 This is the bot i created for the Google-sponsored AI Challenge 2011 (Ants).
 I know it's a mess, but it made me win the first place.
 
-You can read my post mortem explaining what the code does at http://xathis.com/posts/ai-challenge-2011-ants.html
+You can read my post mortem explaining what the code does at http://xathis.com/posts/ai-challenge-2011-ants.html (See: https://web.archive.org/web/20160828072456/http://xathis.com/posts/ai-challenge-2011-ants.html)
 
 Everything interesting is located in Strategy.java


### PR DESCRIPTION
The old post mortem link is no longer valid. Here is a link to web.archive.org which is the last cached version before the webpage disappeared.